### PR TITLE
fix OCI terraform apply

### DIFF
--- a/config/profiles/hardware/oracle/common.nix
+++ b/config/profiles/hardware/oracle/common.nix
@@ -215,6 +215,8 @@ in
               };
               lifecycle.ignoreChanges = [
                 "source_details[0].source_id"
+                "create_vnic_details[0].defined_tags"
+                "defined_tags"
                 "metadata"
               ];
               connection = {


### PR DESCRIPTION
Works around an upstream issue that prevents terraform apply from working.

```
Error: 400-RelatedResourceNotAuthorizedOrNotFound
Error Message: The following tag namespaces / keys are not authorized or not found: 'oracle-tags'
```