### PR TITLE
fix: Revert "chore: remove empty hass configs"

### DIFF
--- a/nixos/systems/tewi/home-assistant.nix
+++ b/nixos/systems/tewi/home-assistant.nix
@@ -149,6 +149,36 @@
       # https://nixos.wiki/wiki/Home_Assistant#Combine_declarative_and_UI_defined_scenes
       "scene manual" = [];
       "scene ui" = "!include scenes.yaml";
+      counter = {};
+      device_tracker = {};
+      energy = {};
+      group = {};
+      history = {};
+      image = {};
+      input_boolean = {};
+      input_datetime = {};
+      input_number = {};
+      input_select = {};
+      input_text = {};
+      logbook = {};
+      map = {};
+      media_source = {};
+      mobile_app = {};
+      my = {};
+      person = {};
+      script = {};
+      ssdp = {};
+      switch = {};
+      stream = {};
+      sun = {};
+      system_health = {};
+      tag = {};
+      template = {};
+      timer = {};
+      webhook = {};
+      wake_on_lan = {};
+      zeroconf = {};
+      zone = {};
       sensor = let
         mkESPresenceBeacon = { device_id, ... }@args: {
           platform = "mqtt_room";
@@ -176,35 +206,7 @@
     ];
     extraComponents = [
       "automation"
-      "counter"
-      "device_tracker"
-      "energy"
-      "group"
-      "history"
-      "image"
-      "input_boolean"
-      "input_datetime"
-      "input_number"
-      "input_select"
-      "input_text"
-      "logbook"
-      "map"
-      "media_source"
-      "mobile_app"
-      "my"
-      "person"
       "scene"
-      "script"
-      "ssdp"
-      "switch"
-      "stream"
-      "sun"
-      "system_health"
-      "tag"
-      "template"
-      "timer"
-      "webhook"
-      "zone"
       "zha"
       "esphome"
       "apple_tv"


### PR DESCRIPTION
This reverts commit 7a17249b9b7b4811813cafba9dc1279f86239038. I don't trust the wiki after all, because now a bunch of integrations are disabled.