### PR TITLE
feat: home-assistant printer integration

### DIFF
--- a/nixos/systems/tewi/home-assistant.nix
+++ b/nixos/systems/tewi/home-assistant.nix
@@ -340,6 +340,8 @@ in {
       "apple_tv"
       "spotify"
       "default_config"
+      "brother"
+      "ipp"
       "cast"
       "plex"
       "met"


### PR DESCRIPTION
fixes errors from logs upon discovery of our printer:
> Error occurred loading configuration flow for integration brother: No module named 'brother'
> Error occurred loading configuration flow for integration ipp: No module named 'pyipp'